### PR TITLE
fix: use `c.Query` in update component chart `city` arg

### DIFF
--- a/Taipei-City-Dashboard-BE/app/controllers/componentConfig.go
+++ b/Taipei-City-Dashboard-BE/app/controllers/componentConfig.go
@@ -210,7 +210,7 @@ func UpdateComponentChartConfig(c *gin.Context) {
 	}
 
 	// 1.1 Get the city name from the URL
-	city := c.Param("city")
+	city := c.Query("city")
 	if !(city == "taipei" || city == "metrotaipei" || city == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return

--- a/Taipei-City-Dashboard-BE/app/controllers/componentConfig.go
+++ b/Taipei-City-Dashboard-BE/app/controllers/componentConfig.go
@@ -28,7 +28,7 @@ GET /api/v1/component
 */
 
 type componentQuery struct {
-	City		  string `form:"city"`
+	City          string `form:"city"`
 	PageSize      int    `form:"pagesize"`
 	PageNum       int    `form:"pagenum"`
 	Sort          string `form:"sort"`
@@ -71,7 +71,7 @@ func GetAllComponents(c *gin.Context) {
 	var query componentQuery
 	c.ShouldBindQuery(&query)
 
-	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == ""){
+	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
@@ -101,12 +101,12 @@ func GetComponentByID(c *gin.Context) {
 	// 1.1 Get the city name from the URL
 	var query componentQuery
 	c.ShouldBindQuery(&query)
-	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == ""){
+	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
 
-	if query.City == ""{
+	if query.City == "" {
 		query.City = "taipei"
 	}
 
@@ -161,12 +161,12 @@ func UpdateComponent(c *gin.Context) {
 	// 1.1 Get the city name from the URL
 	var query componentQuery
 	c.ShouldBindQuery(&query)
-	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == ""){
+	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
 
-	if query.City == ""{
+	if query.City == "" {
 		query.City = "taipei"
 	}
 
@@ -211,12 +211,12 @@ func UpdateComponentChartConfig(c *gin.Context) {
 
 	// 1.1 Get the city name from the URL
 	city := c.Param("city")
-	if !(city == "taipei" || city == "metrotaipei" || city == ""){
+	if !(city == "taipei" || city == "metrotaipei" || city == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
 
-	if city == ""{
+	if city == "" {
 		city = "taipei"
 	}
 
@@ -296,12 +296,12 @@ func DeleteComponent(c *gin.Context) {
 
 	// 1.1 Get the city name from the URL
 	city := c.Param("city")
-	if !(city == "taipei" || city == "metrotaipei" || city == ""){
+	if !(city == "taipei" || city == "metrotaipei" || city == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
 
-	if city == ""{
+	if city == "" {
 		city = "taipei"
 	}
 

--- a/Taipei-City-Dashboard-BE/app/controllers/componentData.go
+++ b/Taipei-City-Dashboard-BE/app/controllers/componentData.go
@@ -28,12 +28,12 @@ func GetComponentChartData(c *gin.Context) {
 	// 1.1 Get the city name from the URL
 	var query componentQuery
 	c.ShouldBindQuery(&query)
-	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == ""){
+	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
 
-	if query.City == ""{
+	if query.City == "" {
 		query.City = "taipei"
 	}
 
@@ -48,7 +48,7 @@ func GetComponentChartData(c *gin.Context) {
 		return
 	}
 
-	timeFrom, timeTo, err:= util.GetTime(c)
+	timeFrom, timeTo, err := util.GetTime(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": err.Error()})
 		return
@@ -109,19 +109,19 @@ func GetComponentHistoryData(c *gin.Context) {
 	// 1.1 Get the city name from the URL
 	var query componentQuery
 	c.ShouldBindQuery(&query)
-	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == ""){
+	if !(query.City == "taipei" || query.City == "metrotaipei" || query.City == "") {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "Invalid City Name"})
 		return
 	}
 
-	if query.City == ""{
+	if query.City == "" {
 		query.City = "taipei"
 	}
 
 	timeFrom, timeTo, err := util.GetTime(c)
-		if err != nil {
+	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": err.Error()})
-			return
+		return
 	}
 	// 2. Get the history data query from the database
 	queryHistory, err := models.GetComponentHistoryDataQuery(id, query.City, timeFrom, timeTo)

--- a/Taipei-City-Dashboard-BE/app/models/componentConfig.go
+++ b/Taipei-City-Dashboard-BE/app/models/componentConfig.go
@@ -14,14 +14,14 @@ import (
 
 // Component is the model for the components table.
 type Component struct {
-	ID             int64           `json:"id" gorm:"column:id;autoincrement;primaryKey"`
-	Index          string          `json:"index" gorm:"column:index;type:varchar;unique;not null"     `
-	Name           string          `json:"name" gorm:"column:name;type:varchar;not null"`
+	ID    int64  `json:"id" gorm:"column:id;autoincrement;primaryKey"`
+	Index string `json:"index" gorm:"column:index;type:varchar;unique;not null"     `
+	Name  string `json:"name" gorm:"column:name;type:varchar;not null"`
 }
 
 // QueryCharts is the model for the query_charts table.
 type QueryCharts struct {
-	Index string                   `json:"index"      gorm:"column:index;type:varchar"`
+	Index          string          `json:"index"      gorm:"column:index;type:varchar"`
 	HistoryConfig  json.RawMessage `json:"history_config" gorm:"column:history_config;type:json"`
 	MapConfigIDs   pq.Int64Array   `json:"-" gorm:"column:map_config_ids;type:integer[]"`
 	MapFilter      json.RawMessage `json:"map_filter" gorm:"column:map_filter;type:json"`
@@ -40,10 +40,10 @@ type QueryCharts struct {
 	QueryType      string          `json:"query_type" gorm:"column:query_type;type:varchar"`
 	QueryChart     string          `json:"-" gorm:"column:query_chart;type:text"`
 	QueryHistory   string          `json:"-" gorm:"column:query_history;type:text"`
-	City		   string          `json:"city" gorm:"column:city;type:text"`
+	City           string          `json:"city" gorm:"column:city;type:text"`
 }
 
-type CityComponent struct{
+type CityComponent struct {
 	ID             int64           `json:"id"`
 	Index          string          `json:"index"`
 	Name           string          `json:"name"`
@@ -67,7 +67,7 @@ type CityComponent struct{
 	QueryType      string          `json:"query_type"`
 	QueryChart     string          `json:"-"`
 	QueryHistory   string          `json:"-"`
-	City		   string          `json:"city"`
+	City           string          `json:"city"`
 }
 
 // ComponentMap is the model for the component_maps table.
@@ -90,19 +90,20 @@ type ComponentChart struct {
 	Types pq.StringArray `json:"types" gorm:"column:types;type:varchar[]"`
 	Unit  string         `json:"unit" gorm:"column:unit;type:varchar"`
 }
+
 /* ----- Handlers ----- */
 
 // createTempComponentDB joins the components, component_maps, and component_charts tables and selects the columns to return.
 func createTempComponentDB() *gorm.DB {
 	subQuery1 := DBManager.Table("components").
-	Select("components.id,components.index,components.name,row_to_json(component_charts.*) AS chart_config").
-	Joins("JOIN component_charts ON components.index = component_charts.index")
+		Select("components.id,components.index,components.name,row_to_json(component_charts.*) AS chart_config").
+		Joins("JOIN component_charts ON components.index = component_charts.index")
 
 	subQuery2 := DBManager.Table("query_charts").
-	Select("query_charts.index,query_charts.city,json_agg(row_to_json(component_maps.*)) as map_config").
-	Joins("LEFT JOIN unnest(query_charts.map_config_ids) AS id_value on true").
-	Joins("LEFT JOIN component_maps ON id_value = component_maps.id").
-	Group("query_charts.index, query_charts.city")
+		Select("query_charts.index,query_charts.city,json_agg(row_to_json(component_maps.*)) as map_config").
+		Joins("LEFT JOIN unnest(query_charts.map_config_ids) AS id_value on true").
+		Joins("LEFT JOIN component_maps ON id_value = component_maps.id").
+		Group("query_charts.index, query_charts.city")
 
 	query := DBManager.Table("(?) as components", subQuery1).
 		Select("*").
@@ -118,7 +119,7 @@ func GetAllComponents(city string, pageSize int, pageNum int, sort string, order
 	// Count the total amount of components
 	tempDB.Count(&totalComponents)
 
-	if city != ""{
+	if city != "" {
 		tempDB = tempDB.Where("query_charts.city = ?", city)
 	}
 
@@ -130,46 +131,46 @@ func GetAllComponents(city string, pageSize int, pageNum int, sort string, order
 		tempDB = tempDB.Where("components.name LIKE ?", "%"+searchByName+"%")
 	}
 
-	componentsColumn := []string{"id","index","name"}
-	queryChartsColumn := []string{"update_freq","source","short_desc","long_desc","use_case","links","contributors","query_type"}
+	componentsColumn := []string{"id", "index", "name"}
+	queryChartsColumn := []string{"update_freq", "source", "short_desc", "long_desc", "use_case", "links", "contributors", "query_type"}
 	allColumns := append(componentsColumn, queryChartsColumn...)
 
 	// Filter the components
-	if filterBy != "" && filterValue != "" && slices.Contains(allColumns,filterBy){
+	if filterBy != "" && filterValue != "" && slices.Contains(allColumns, filterBy) {
 		var filterByCol string
-		if slices.Contains(componentsColumn,filterBy){
+		if slices.Contains(componentsColumn, filterBy) {
 			filterByCol = "components"
 		}
 
-		if slices.Contains(queryChartsColumn,filterBy){
+		if slices.Contains(queryChartsColumn, filterBy) {
 			filterByCol = "query_charts"
 		}
 
 		switch filterMode {
 		case "eq": // equals
-			tempDB = tempDB.Where(filterByCol + ".\"?\" = ?", gorm.Expr(filterBy), filterValue)
+			tempDB = tempDB.Where(filterByCol+".\"?\" = ?", gorm.Expr(filterBy), filterValue)
 		case "ne": // not equals
-			tempDB = tempDB.Where(filterByCol + ".\"?\" <> ?", gorm.Expr(filterBy), filterValue)
+			tempDB = tempDB.Where(filterByCol+".\"?\" <> ?", gorm.Expr(filterBy), filterValue)
 		case "gt": // greater than
-			tempDB = tempDB.Where(filterByCol + ".\"?\" > ?", gorm.Expr(filterBy), filterValue)
+			tempDB = tempDB.Where(filterByCol+".\"?\" > ?", gorm.Expr(filterBy), filterValue)
 		case "lt": // less than
-			tempDB = tempDB.Where(filterByCol + ".\"?\" < ?", gorm.Expr(filterBy), filterValue)
+			tempDB = tempDB.Where(filterByCol+".\"?\" < ?", gorm.Expr(filterBy), filterValue)
 		case "in": // value in array
-			tempDB = tempDB.Where(filterByCol + ".\"?\" IN ?", gorm.Expr(filterBy), filterValue)
+			tempDB = tempDB.Where(filterByCol+".\"?\" IN ?", gorm.Expr(filterBy), filterValue)
 		default: // Default to eq
-			tempDB = tempDB.Where(filterByCol + ".\"?\" = ?", gorm.Expr(filterBy), filterValue)
+			tempDB = tempDB.Where(filterByCol+".\"?\" = ?", gorm.Expr(filterBy), filterValue)
 		}
 	}
 
 	tempDB.Count(&resultNum)
 
 	// Sort the components
-	if sort != "" && slices.Contains(allColumns,sort){
-		if slices.Contains(componentsColumn,sort){
+	if sort != "" && slices.Contains(allColumns, sort) {
+		if slices.Contains(componentsColumn, sort) {
 			tempDB = tempDB.Order("components." + sort + " " + order)
 		}
 
-		if slices.Contains(queryChartsColumn,sort){
+		if slices.Contains(queryChartsColumn, sort) {
 			tempDB = tempDB.Order("query_charts." + sort + " " + order)
 		}
 	}
@@ -208,41 +209,40 @@ func GetComponentByIDAll(id int) (component []CityComponent, err error) {
 	return component, nil
 }
 
-
 func CreateComponent(index string, name string, city string, historyConfig json.RawMessage, mapFilter json.RawMessage, timeFrom string, timeTo *string, updateFreq *int64, updateFreqUnit string, source string, shortDesc string, longDesc string, useCase string, links pq.StringArray, contributors pq.StringArray) (cityComponent CityComponent, err error) {
-    // component := Component{
+	// component := Component{
 	// 	Index:			 index,
-    //     Name:            name,
-    //     // HistoryConfig:   historyConfig,
-    //     // MapFilter:       mapFilter,
-    //     // TimeFrom:        timeFrom,
-    //     // TimeTo:          timeTo,
-    //     // UpdateFreq:      updateFreq,
-    //     // UpdateFreqUnit:  updateFreqUnit,
-    //     // Source:          source,
-    //     // ShortDesc:       shortDesc,
-    //     // LongDesc:        longDesc,
-    //     // UseCase:         useCase,
-    //     // Links:           links,
-    //     // Contributors:    contributors,
-    //     // CreatedAt:       time.Now(),
-    //     // UpdatedAt:       time.Now(),
-    // }
+	//     Name:            name,
+	//     // HistoryConfig:   historyConfig,
+	//     // MapFilter:       mapFilter,
+	//     // TimeFrom:        timeFrom,
+	//     // TimeTo:          timeTo,
+	//     // UpdateFreq:      updateFreq,
+	//     // UpdateFreqUnit:  updateFreqUnit,
+	//     // Source:          source,
+	//     // ShortDesc:       shortDesc,
+	//     // LongDesc:        longDesc,
+	//     // UseCase:         useCase,
+	//     // Links:           links,
+	//     // Contributors:    contributors,
+	//     // CreatedAt:       time.Now(),
+	//     // UpdatedAt:       time.Now(),
+	// }
 
 	// queryCharts := QueryCharts{
 	// 	City: city,
-	// 	HistoryConfig: historyConfig, 
-	// 	MapFilter: mapFilter, 
-	// 	TimeFrom: timeFrom, 
-	// 	TimeTo: timeTo, 
-	// 	UpdateFreq: updateFreq, 
-	// 	UpdateFreqUnit: updateFreqUnit, 
-	// 	Source: source, 
-	// 	ShortDesc: shortDesc, 
-	// 	LongDesc: longDesc, 
-	// 	UseCase: useCase, 
-	// 	Links: links, 
-	// 	Contributors: contributors, 
+	// 	HistoryConfig: historyConfig,
+	// 	MapFilter: mapFilter,
+	// 	TimeFrom: timeFrom,
+	// 	TimeTo: timeTo,
+	// 	UpdateFreq: updateFreq,
+	// 	UpdateFreqUnit: updateFreqUnit,
+	// 	Source: source,
+	// 	ShortDesc: shortDesc,
+	// 	LongDesc: longDesc,
+	// 	UseCase: useCase,
+	// 	Links: links,
+	// 	Contributors: contributors,
 	// 	CreatedAt: time.Now(),
 	// 	UpdatedAt: time.Now(),
 	// }
@@ -250,17 +250,17 @@ func CreateComponent(index string, name string, city string, historyConfig json.
 	// cityComponent = CityComponent{
 	// 	Name: name,
 	// 	City: city,
-	// 	HistoryConfig: historyConfig, 
-	// 	MapFilter: mapFilter, 
-	// 	TimeFrom: timeFrom, 
-	// 	TimeTo: timeTo, 
-	// 	UpdateFreq: updateFreq, 
-	// 	UpdateFreqUnit: updateFreqUnit, 
-	// 	Source: source, 
-	// 	ShortDesc: shortDesc, 
-	// 	LongDesc: longDesc, 
-	// 	UseCase: useCase, 
-	// 	Links: links, 
+	// 	HistoryConfig: historyConfig,
+	// 	MapFilter: mapFilter,
+	// 	TimeFrom: timeFrom,
+	// 	TimeTo: timeTo,
+	// 	UpdateFreq: updateFreq,
+	// 	UpdateFreqUnit: updateFreqUnit,
+	// 	Source: source,
+	// 	ShortDesc: shortDesc,
+	// 	LongDesc: longDesc,
+	// 	UseCase: useCase,
+	// 	Links: links,
 	// 	Contributors: contributors,
 	// 	CreatedAt: time.Now(),
 	// 	UpdatedAt: time.Now(),
@@ -269,10 +269,10 @@ func CreateComponent(index string, name string, city string, historyConfig json.
 	// 建立 logic 還不確定，無法實作
 	// 首先建立 components => 其次建立 query_charts ，但是 query_charts 有多個城市，不確定是一個建立還是同時建立
 
-    // err = DBManager.Table("components").Create(&component).Error
-    // if err != nil {
-    //     return component, err
-    // }
+	// err = DBManager.Table("components").Create(&component).Error
+	// if err != nil {
+	//     return component, err
+	// }
 
 	// var tmp Component
 	// err = DBManager.Table("components").Where("name = ?", name).First(&tmp).Error
@@ -280,75 +280,73 @@ func CreateComponent(index string, name string, city string, historyConfig json.
 	// 	err = DBManager.Table("components").Create(&component).Error
 	// 	if err != nil {
 	// 		return cityComponent, err
-	// 	}	
+	// 	}
 	// }
 
-
 	// err = DBManager.Table("query_charts").Create(&queryCharts).Error
-    // if err != nil {
-    //     return cityComponent, err
-    // }
+	// if err != nil {
+	//     return cityComponent, err
+	// }
 
-    return cityComponent, nil
+	return cityComponent, nil
 }
 
 func UpdateComponent(id int, city string, name string, historyConfig json.RawMessage, mapFilter json.RawMessage, timeFrom string, timeTo *string, updateFreq *int64, updateFreqUnit string, source string, shortDesc string, longDesc string, useCase string, links pq.StringArray, contributors pq.StringArray) (cityComponent CityComponent, err error) {
 	component := Component{
-		Name: name, 
-		// HistoryConfig: historyConfig, 
-		// MapFilter: mapFilter, 
-		// TimeFrom: timeFrom, 
-		// TimeTo: timeTo, 
-		// UpdateFreq: updateFreq, 
-		// UpdateFreqUnit: updateFreqUnit, 
-		// Source: source, 
-		// ShortDesc: shortDesc, 
-		// LongDesc: longDesc, 
-		// UseCase: useCase, 
-		// Links: links, 
-		// Contributors: contributors, 
+		Name: name,
+		// HistoryConfig: historyConfig,
+		// MapFilter: mapFilter,
+		// TimeFrom: timeFrom,
+		// TimeTo: timeTo,
+		// UpdateFreq: updateFreq,
+		// UpdateFreqUnit: updateFreqUnit,
+		// Source: source,
+		// ShortDesc: shortDesc,
+		// LongDesc: longDesc,
+		// UseCase: useCase,
+		// Links: links,
+		// Contributors: contributors,
 		// UpdatedAt: time.Now()
 	}
 
 	queryCharts := QueryCharts{
-		City: city,
-		HistoryConfig: historyConfig, 
-		MapFilter: mapFilter, 
-		TimeFrom: timeFrom, 
-		TimeTo: timeTo, 
-		UpdateFreq: updateFreq, 
-		UpdateFreqUnit: updateFreqUnit, 
-		Source: source, 
-		ShortDesc: shortDesc, 
-		LongDesc: longDesc, 
-		UseCase: useCase, 
-		Links: links, 
-		Contributors: contributors, 
-		UpdatedAt: time.Now(),
+		City:           city,
+		HistoryConfig:  historyConfig,
+		MapFilter:      mapFilter,
+		TimeFrom:       timeFrom,
+		TimeTo:         timeTo,
+		UpdateFreq:     updateFreq,
+		UpdateFreqUnit: updateFreqUnit,
+		Source:         source,
+		ShortDesc:      shortDesc,
+		LongDesc:       longDesc,
+		UseCase:        useCase,
+		Links:          links,
+		Contributors:   contributors,
+		UpdatedAt:      time.Now(),
 	}
 
 	cityComponent = CityComponent{
-		Name: name,
-		City: city,
-		HistoryConfig: historyConfig, 
-		MapFilter: mapFilter, 
-		TimeFrom: timeFrom, 
-		TimeTo: timeTo, 
-		UpdateFreq: updateFreq, 
-		UpdateFreqUnit: updateFreqUnit, 
-		Source: source, 
-		ShortDesc: shortDesc, 
-		LongDesc: longDesc, 
-		UseCase: useCase, 
-		Links: links, 
-		Contributors: contributors, 
-		UpdatedAt: time.Now(),
+		Name:           name,
+		City:           city,
+		HistoryConfig:  historyConfig,
+		MapFilter:      mapFilter,
+		TimeFrom:       timeFrom,
+		TimeTo:         timeTo,
+		UpdateFreq:     updateFreq,
+		UpdateFreqUnit: updateFreqUnit,
+		Source:         source,
+		ShortDesc:      shortDesc,
+		LongDesc:       longDesc,
+		UseCase:        useCase,
+		Links:          links,
+		Contributors:   contributors,
+		UpdatedAt:      time.Now(),
 	}
 
-	
 	var tmp Component
 	err = DBManager.Table("components").Where("id = ?", id).First(&tmp).Error
-	if err != nil{
+	if err != nil {
 		return cityComponent, err
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

Fix the issue where the components with `city = metrotaipei` cannot be updated.
The root cause is the misuse of `c.Param` in place of `c.Query` in `UpdateComponentChartConfig`

## Type (Fill in "x" to check)

- [x] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [x] Code linter has been run and issues have all been resolved
- [x] The code has been thoroughly tested and no visible bugs have been introduced
- [x] The pull request will completely resolve the issue(s) mentioned
- [x] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
